### PR TITLE
Design: 투두리스트 css 수정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,10 @@
 		work correctly both with client-side routing and a non-root public URL.
 		Learn how to configure a non-root public URL by running `npm run build`.
 	-->
+		<link
+			rel="stylesheet"
+			href="//cdn.jsdelivr.net/npm/font-applesdgothicneo@1.0/all.min.css"
+		/>
 		<title>React App</title>
 	</head>
 	<body>

--- a/src/GlobalStyle.js
+++ b/src/GlobalStyle.js
@@ -9,15 +9,15 @@ const GlobalStyles = createGlobalStyle`
     box-sizing: border-box;
     margin: 0;
   }
-
+  
   body, div, span, h1, h2, h3, h4, h5, h6,
   p, i, ol, ul, li, form, label, header, nav, 
   input, textarea, button {
-	margin: 0;
-	padding: 0;
-	border: 0;
-  font-weight: normal;
-  /* font-family: */
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-weight: normal;
+    font-family: 'AppleSDGothicNeo', 'Noto Sans KR', sans-serif;
   }
 
   textarea {

--- a/src/common/box/Box.jsx
+++ b/src/common/box/Box.jsx
@@ -25,7 +25,7 @@ const StBox = styled.div`
 				return css`
 					background-color: white;
 					width: 279px;
-					height: 356px;
+					height: 258px;
 					border-radius: 10px;
 					padding: 21px 26px 14px 26px;
 					position: fixed;
@@ -38,6 +38,15 @@ const StBox = styled.div`
 					height: 48px;
 					padding: 12px 0;
 				`;
+
+			// 메모 아이콘 박스
+			case "memoIconBox":
+				return css`
+					width: 20px;
+					height: 20px;
+					padding: 5px 0 0 2px;
+				`;
+
 			// 텍스트 박스
 			case "textArea":
 				return css`

--- a/src/common/flex/Flex.jsx
+++ b/src/common/flex/Flex.jsx
@@ -37,6 +37,7 @@ export const StFlex = styled.div`
 
 	/* 위치 */
 	top: ${({ top }) => top};
+	bottom: ${({ bottom }) => bottom};
 	left: ${({ left }) => left};
 	right: ${({ right }) => right};
 	position: ${({ position }) => position};

--- a/src/common/form/Form.jsx
+++ b/src/common/form/Form.jsx
@@ -11,7 +11,7 @@ const StForm = styled.form`
 			// 투두 작성 폼
 			case "todoForm":
 				return css`
-					height: 300px;
+					height: 200px;
 					display: flex;
 					flex-direction: column;
 					color: #979797;

--- a/src/common/textArea/TextArea.jsx
+++ b/src/common/textArea/TextArea.jsx
@@ -10,6 +10,7 @@ const StTextArea = styled.textarea`
 		switch (variant) {
 			case "memo":
 				return css`
+					width: 100%;
 					vertical-align: center;
 					font-size: 13px;
 					font-weight: 500;

--- a/src/components/todoList/ListingTodos.jsx
+++ b/src/components/todoList/ListingTodos.jsx
@@ -32,11 +32,6 @@ const ListingTodos = ({ todoList }) => {
 					<Text variant="greyBig">플랜이 없어요! 추가해주세요</Text>
 				</Flex>
 			)}
-
-			{/* 투두 추가 모달 오픈 버튼 */}
-			<Flex wd="100%" jc="flex-end">
-				<Svg onClick={openAddTodoModalHandler} variant="addTodo" />
-			</Flex>
 		</Flex>
 	);
 };

--- a/src/components/todoList/ModalAddTodo.jsx
+++ b/src/components/todoList/ModalAddTodo.jsx
@@ -74,7 +74,7 @@ const ModalAddTodo = () => {
 								/>
 							</Flex>
 
-							<Flex gap="18.5px" ai="flex-start" mg="14px 0 0 0">
+							<Flex gap="10px" ai="flex-start" mg="14px 0 0 0">
 								{/* 메모 아이콘 */}
 								<Box variant="memoIconBox">
 									<Svg variant="memo" />
@@ -88,8 +88,6 @@ const ModalAddTodo = () => {
 									variant="memo"
 									placeholder="메모"
 									maxLength="100"
-									rows="5"
-									cols="29"
 								/>
 							</Flex>
 						</div>

--- a/src/components/todoList/TodoItem.jsx
+++ b/src/components/todoList/TodoItem.jsx
@@ -18,28 +18,27 @@ const TodoItem = props => {
 	return (
 		<>
 			{/* 투두 박스 */}
-			<Flex wd="100%" ht="51px" radius="10px" bg="#FFFFFF" pd="12px 10px">
-				{/* icons: 햄버거, 체크박스 */}
-				<Flex gap="7px">
-					{/* 햄버거 */}
-					<Svg variant="hamburger" />
-					{/* 체크박스 */}
-					{completed ? (
-						<Svg onClick={checkTodoHandler} variant="todoCompleted" />
-					) : (
-						<Svg onClick={checkTodoHandler} variant="checkBox" />
-					)}
-				</Flex>
+			<Flex wd="100%" ht="51px" radius="10px" bg="#FFFFFF" pd="13.5px 15px">
+				{/* 체크박스 */}
+				{completed ? (
+					<Svg onClick={checkTodoHandler} variant="todoCompleted" />
+				) : (
+					<Svg onClick={checkTodoHandler} variant="checkBox" />
+				)}
 
 				{/* 투두 컨텐트 */}
 				<Flex
 					onClick={onClickTodoItemHandler}
 					jc="flex-start"
 					wd="100%"
-					mg="0 0 0 16px"
+					mg="0 0 0 13px"
+					pd="3px 0 0 0"
 				>
 					<Text variant="normal">{todoContent}</Text>
 				</Flex>
+
+				{/* 햄버거 */}
+				<Svg variant="hamburger" />
 			</Flex>
 		</>
 	);

--- a/src/pages/todoList/TodoListPage.jsx
+++ b/src/pages/todoList/TodoListPage.jsx
@@ -1,15 +1,29 @@
-import { Box, Flex } from "../../common";
+import { useDispatch } from "react-redux";
+import { Box, Flex, Svg } from "../../common";
 import {
 	TodoListCalendar,
 	ListingTodos,
 	TodoListHeader,
 } from "../../components";
+import { updateIsAddTodoModalOpen } from "../../redux/modules/modal/modalSlice";
 
 const TodoListPage = () => {
+	const dispatch = useDispatch();
+
+	const openAddTodoModalHandler = () => {
+		dispatch(updateIsAddTodoModalOpen());
+	};
+
 	return (
-		<Flex dir="column" ht="100%">
-			<TodoListCalendar />
-		</Flex>
+		<>
+			<Flex dir="column" ht="100vh" bg="#F9F9F9">
+				<TodoListCalendar />
+				{/* 투두 추가 모달 오픈 버튼 */}
+				<Flex wd="100%" position="sticky" bottom="70px" jc="flex-end" pd="10px">
+					<Svg onClick={openAddTodoModalHandler} variant="addTodo" />
+				</Flex>
+			</Flex>
+		</>
 	);
 };
 


### PR DESCRIPTION
- 투두리스트 페이지 세로 길이가 화면에 꽉 차도록 수정
- 투두 추가 모달 오픈 버튼이 화면에 플로팅 되도록 수정

- index.html과 GlobalStyle.js에 폰트 스타일 코드 추가
- 투두 아이템의 햄버거 아이콘 위치 수정
- 모달창 디자인 변경(세로 사이즈 변경, 여백값 수정)