### PR TITLE
Feat: 피드 단건 조회 기능 구현

### DIFF
--- a/src/components/feed/FeedItem.jsx
+++ b/src/components/feed/FeedItem.jsx
@@ -3,6 +3,7 @@ import { FeedItemUi } from "../../components";
 
 const FeedItem = ({ feedItem }) => {
 	const {
+		feedId,
 		feedTitle,
 		nickname,
 		profileImageUrl,
@@ -13,7 +14,7 @@ const FeedItem = ({ feedItem }) => {
 		feedColor,
 	} = feedItem;
 	return (
-		<FeedItemUi feedColor={feedColor}>
+		<FeedItemUi feedId={feedId} feedColor={feedColor}>
 			<Flex ht="100%" dir="column" jc="space-between">
 				{/* 상단 */}
 				<Flex dir="column" ai="center" gap="15px">

--- a/src/components/feed/FeedItemUi.jsx
+++ b/src/components/feed/FeedItemUi.jsx
@@ -1,8 +1,20 @@
+import { useNavigate } from "react-router-dom";
 import { Box, Flex } from "../../common";
 
-const FeedItemUi = ({ children, feedColor }) => {
+const FeedItemUi = ({ feedId, children, feedColor }) => {
+	const navigate = useNavigate();
+	const onClickHandler = () => {
+		navigate(`/feed/${feedId}`);
+	};
+
 	return (
-		<Flex dir="column" wd="100%" ht="193px" cursor="pointer">
+		<Flex
+			dir="column"
+			wd="100%"
+			ht="193px"
+			cursor="pointer"
+			onClick={onClickHandler}
+		>
 			<Flex jc="center" gap="62px">
 				<Box feedColor={feedColor} variant="feedItemHead" />
 				<Box feedColor={feedColor} variant="feedItemHead" />

--- a/src/pages/feed/DetailFeedPage.jsx
+++ b/src/pages/feed/DetailFeedPage.jsx
@@ -1,12 +1,29 @@
+import { useEffect } from "react";
+import { useSelector } from "react-redux";
 import { useDispatch } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 import { FirstHeading, Flex, Image, SecondHeading, Svg } from "../../common";
 import { FeedComment } from "../../components";
+import { __getFeedItem } from "../../redux/modules/feed/feedSlice";
 
 const DetailFeedPage = () => {
 	const navigate = useNavigate();
 	const dispatch = useDispatch();
 	const { id } = useParams();
+
+	const feedItem = useSelector(state => state.feed.feedItem);
+
+	const {
+		commentResponseDtoList,
+		countComment,
+		countReaction,
+		currentReactionType,
+		reactionResponseDtoList,
+	} = feedItem;
+
+	useEffect(() => {
+		dispatch(__getFeedItem(id));
+	}, []);
 
 	return (
 		<>
@@ -212,7 +229,13 @@ const DetailFeedPage = () => {
 						</Flex>
 					</Flex>
 				</Flex>
-				<FeedComment />
+				<FeedComment
+					commentResponseDtoList={commentResponseDtoList}
+					countComment={countComment}
+					countReaction={countReaction}
+					currentReactionType={currentReactionType}
+					reactionResponseDtoList={reactionResponseDtoList}
+				/>
 			</Flex>
 		</>
 	);

--- a/src/redux/modules/feed/feedSlice.js
+++ b/src/redux/modules/feed/feedSlice.js
@@ -19,6 +19,21 @@ export const __getFollowingFeeds = createAsyncThunk(
 	},
 );
 
+// 피드 단건 조회 Thunk
+export const __getFeedItem = createAsyncThunk(
+	"feed/getFeedItem",
+	async (payload, thunkAPI) => {
+		try {
+			const response = await axios.get(`${serverUrl}/api/feed/${payload}`, {
+				headers: { Authorization: accessToken },
+			});
+			return thunkAPI.fulfillWithValue(response.data);
+		} catch (error) {
+			return thunkAPI.rejectWithValue(error.response.data);
+		}
+	},
+);
+
 // 추천 피드 조회 Thunk
 export const __getRecommendedFeeds = createAsyncThunk(
 	"feed/getRecommendedFeeds",
@@ -38,6 +53,7 @@ const initialState = {
 	feedList: [],
 	checkedList: [],
 	tagList: [],
+	feedItem: {},
 };
 
 export const feedSlice = createSlice({
@@ -85,6 +101,10 @@ export const feedSlice = createSlice({
 			// 추천 피드 조회 성공
 			.addCase(__getRecommendedFeeds.fulfilled, (state, action) => {
 				state.feedList = action.payload;
+			})
+			// 피드 단건 조회 성공
+			.addCase(__getFeedItem.fulfilled, (state, action) => {
+				state.feedItem = action.payload;
 			});
 	},
 });


### PR DESCRIPTION
피드 목록 조회에서 피드 아이템을 클릭했을 때 해당 피드 상세 페이지로 이동하도록 함
댓글, 리액션 관련 데이터를 FeedComment 컴포넌트에 props로 넘겨주도록 함
피드 단건 조회 thunk, extrareducer 추가
