### PR TITLE
Feat: 피드 디테일 페이지 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"axios": "^1.1.3",
 		"classnames": "^2.3.2",
 		"cross-env": "^7.0.3",
+		"dayjs": "^1.11.6",
 		"global": "^4.4.0",
 		"jwt-decode": "^3.1.2",
 		"moment": "^2.29.4",

--- a/src/common/box/Box.jsx
+++ b/src/common/box/Box.jsx
@@ -329,8 +329,8 @@ const StBox = styled.div`
 					background-repeat: no-repeat;
 					background-size: cover;
 					border-radius: 50%;
-					width: 24px;
-					height: 24px;
+					width: 34px;
+					height: 34px;
 				`;
 
 			// 프로필 이미지 디폴트 스몰
@@ -351,10 +351,10 @@ const StBox = styled.div`
 					background-repeat: no-repeat;
 					background-size: cover;
 					background-position: center;
-					width: 375px;
+					width: 100%;
 					height: 200px;
-					background-color: #f8f8f8;
 				`;
+
 			// 네비게이션 바 아이콘
 			case "navIconBox":
 				return css`

--- a/src/common/box/Box.jsx
+++ b/src/common/box/Box.jsx
@@ -10,7 +10,7 @@ const StBox = styled.div`
 	width: "100%";
 	height: "100vh";
 
-	${({ variant, profileImageUrl, feedColor, type }) => {
+	${({ variant, profileImageUrl, feedColor, type, feedImgUrl }) => {
 		switch (variant) {
 			// 투두리스트 전체 영역
 			case "todoListArea":
@@ -322,6 +322,17 @@ const StBox = styled.div`
 					height: 24px;
 				`;
 
+			// 프로필 이미지 보통
+			case "profilePicNormal":
+				return css`
+					background-image: url(${profileImageUrl});
+					background-repeat: no-repeat;
+					background-size: cover;
+					border-radius: 50%;
+					width: 24px;
+					height: 24px;
+				`;
+
 			// 프로필 이미지 디폴트 스몰
 			case "profilePicDefaultSmall":
 				return css`
@@ -333,6 +344,17 @@ const StBox = styled.div`
 					height: 24px;
 				`;
 
+			// 피드 사진
+			case "feedImg":
+				return css`
+					background-image: url(${feedImgUrl});
+					background-repeat: no-repeat;
+					background-size: cover;
+					background-position: center;
+					width: 375px;
+					height: 200px;
+					background-color: #f8f8f8;
+				`;
 			// 네비게이션 바 아이콘
 			case "navIconBox":
 				return css`
@@ -342,7 +364,6 @@ const StBox = styled.div`
 					width: 17px;
 					height: 16px;
 				`;
-
 			default:
 				break;
 		}

--- a/src/common/text/Text.jsx
+++ b/src/common/text/Text.jsx
@@ -80,6 +80,7 @@ const StText = styled.span`
 				return css`
 					font-weight: 400;
 					font-size: 14px;
+					line-height: 27px;
 				`;
 			case "selectedTabMenu":
 				return css`
@@ -90,6 +91,27 @@ const StText = styled.span`
 				return css`
 					font-weight: 400;
 					font-size: 10px;
+				`;
+
+			// 피드 상세
+			case "red":
+				return css`
+					font-weight: 500;
+					font-size: 12px;
+					color: #fd3049;
+				`;
+			case "orange":
+				return css`
+					font-weight: 500;
+					font-size: 10px;
+					color: #ff8737;
+				`;
+			case "title":
+				return css`
+					font-weight: 700;
+					font-size: 22px;
+					line-height: 33px;
+					color: #131313;
 				`;
 			default:
 				break;

--- a/src/pages/feed/DetailFeedPage.jsx
+++ b/src/pages/feed/DetailFeedPage.jsx
@@ -53,7 +53,10 @@ const DetailFeedPage = () => {
 					<Flex wd="100%" ht="66px" jc="space-between" pd="14px 20px">
 						<Flex jc="flex-start" gap="10px">
 							{/* 프로필 사진 */}
-							<Flex>
+							<Flex
+								onClick={() => navigate(`/profile/${memberId}`)}
+								cursor="pointer"
+							>
 								<Box
 									variant="profilePicNormal"
 									profileImageUrl={profileImageUrl}
@@ -68,7 +71,12 @@ const DetailFeedPage = () => {
 							>
 								{/* 닉네임, 뱃지 */}
 								<Flex ht="100%" ai="center" gap="4px">
-									<Text variant="selectedTabMenu">{nickname}</Text>
+									<Flex
+										onClick={() => navigate(`/profile/${memberId}`)}
+										cursor="pointer"
+									>
+										<Text variant="selectedTabMenu">{nickname}</Text>
+									</Flex>
 									<Flex
 										wd="60px"
 										ht="20px"

--- a/src/pages/feed/DetailFeedPage.jsx
+++ b/src/pages/feed/DetailFeedPage.jsx
@@ -1,10 +1,11 @@
 import dayjs from "dayjs";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 import { Box, Flex, Svg, Text } from "../../common";
 import { FeedComment } from "../../components";
 import { __getFeedItem } from "../../redux/modules/feed/feedSlice";
+import { __followThunk } from "../../redux/modules/profileSlice";
 
 const DetailFeedPage = () => {
 	const navigate = useNavigate();
@@ -32,9 +33,17 @@ const DetailFeedPage = () => {
 		reactionResponseDtoList,
 	} = feedItem;
 
+	const [isfollowing, setIsFollowing] = useState(followOrNot);
+
 	useEffect(() => {
 		dispatch(__getFeedItem(id));
+		setIsFollowing(followOrNot);
 	}, []);
+
+	const onClickFollowHandler = () => {
+		dispatch(__followThunk(memberId));
+		setIsFollowing(!isfollowing);
+	};
 
 	return (
 		<>
@@ -99,7 +108,11 @@ const DetailFeedPage = () => {
 						<Flex>
 							{/* 팔로우 버튼 */}
 							<Flex>
-								<Svg variant="follow" onClick={() => {}}></Svg>
+								{isfollowing ? (
+									<Svg variant="followCancel" onClick={onClickFollowHandler} />
+								) : (
+									<Svg variant="follow" onClick={onClickFollowHandler} />
+								)}
 							</Flex>
 						</Flex>
 					</Flex>

--- a/src/pages/feed/DetailFeedPage.jsx
+++ b/src/pages/feed/DetailFeedPage.jsx
@@ -1,8 +1,9 @@
+import dayjs from "dayjs";
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useDispatch } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
-import { FirstHeading, Flex, Image, SecondHeading, Svg } from "../../common";
+import { Box, FirstHeading, Flex, SecondHeading, Svg } from "../../common";
 import { FeedComment } from "../../components";
 import { __getFeedItem } from "../../redux/modules/feed/feedSlice";
 
@@ -14,6 +15,17 @@ const DetailFeedPage = () => {
 	const feedItem = useSelector(state => state.feed.feedItem);
 
 	const {
+		feedId,
+		feedTitle,
+		feedContent,
+		todoList,
+		feedImagesUrlList,
+		tagList,
+		postedAt,
+		memberId,
+		nickname,
+		profileImageUrl,
+		followOrNot,
 		commentResponseDtoList,
 		countComment,
 		countReaction,
@@ -50,14 +62,9 @@ const DetailFeedPage = () => {
 					<Flex wd="335px" jc="space-between" mg="0 0 20px 0">
 						<Flex wd="335px" jc="flex-start">
 							<Flex>
-								<Image
-									variant="followImage"
-									// src={.profileImage}
-									alt=""
-									style={{ marginTop: "4px", backgroundColor: "blue" }}
-									onClick={() => {
-										// anotherMemberPage(.memberId);
-									}}
+								<Box
+									variant="profilePicNormal"
+									profileImageUrl={profileImageUrl}
 								/>
 							</Flex>
 							<Flex dir="column" ai="flex-start">
@@ -69,7 +76,7 @@ const DetailFeedPage = () => {
 											// anotherMemberPage(.memberId);
 										}}
 									>
-										닉네임입니다
+										{nickname}
 										<Flex
 											bc="#FFF4ED"
 											color="#FF8737"
@@ -83,7 +90,7 @@ const DetailFeedPage = () => {
 								</Flex>
 								<Flex>
 									<SecondHeading fw="600" fs="12px" color="#A2A2A2">
-										2022.11.21 14:34
+										{dayjs(postedAt).format(`YYYY.MM.DD HH:mm`)}
 									</SecondHeading>
 								</Flex>
 							</Flex>
@@ -101,9 +108,9 @@ const DetailFeedPage = () => {
 						color="#131313"
 						mg="0 0 30px 0"
 						lh="30"
+						jc="flex-start"
 					>
-						피드 제목입니다. 피드 제목입니다. 피드 제목입니다. 피드 제목입니다.
-						피드 제목입니다.
+						{feedTitle}
 					</Flex>
 					<Flex
 						dir="column"
@@ -115,23 +122,15 @@ const DetailFeedPage = () => {
 						pd="20px"
 						mg="0 0 20px 0"
 					>
-						<Flex mg="5px">
-							<Svg variant="feedCheck"></Svg>
-							<FirstHeading fw="300" fs="14px" color="#131313">
-								아침 5시에 일어나기
-							</FirstHeading>
-						</Flex>
-						<Flex mg="5px">
-							<Svg variant="feedCheck"></Svg>
-							<FirstHeading fw="300" fs="14px" color="#131313">
-								영양제 챙겨먹기
-							</FirstHeading>
-						</Flex>
-						<Flex mg="5px">
-							<Svg variant="feedCheck"></Svg>
-							<FirstHeading fw="300" fs="14px" color="#131313">
-								일어나서 콩이 산책 다녀오기
-							</FirstHeading>
+						<Flex mg="5px" dir="column">
+							{todoList?.map((todoItem, index) => (
+								<Flex key={index} dir="row">
+									<Svg variant="feedCheck"></Svg>
+									<FirstHeading fw="300" fs="14px" color="#131313">
+										{todoItem}
+									</FirstHeading>
+								</Flex>
+							))}
 						</Flex>
 					</Flex>
 					<Flex
@@ -141,91 +140,30 @@ const DetailFeedPage = () => {
 						fs="14px"
 						color="#131313"
 						mg="0 0 20px 0"
+						jc="flex-start"
 					>
-						상세 내용은 사용자에게 최대 100자 보여집니다. 상세 내용은 사용자에게
-						최대 100자 보여집니다. 상세 내용은 사용자에게 최대 100자 보여집니다.
-						상세 내용은 사용자에게 최대 100자 보여집니다. 상세 내용은 사용자에게
-						최대
+						{feedContent}
 					</Flex>
-					<Flex wd="375px" ht="200px" bc="#F8F8F8" mg="0 0 20px 0"></Flex>
+					{feedImagesUrlList?.map((feedImg, index) => (
+						<Box variant="feedImg" feedImgUrl={feedImg} />
+					))}
 					<Flex wd="335px" dir="column">
 						<Flex wd="335px" jc="flex-start" mg="0 0 10px 0">
-							<Flex
-								wd="95px"
-								ht="29px"
-								bg="#fff"
-								border="1px solid #E5E5E5"
-								radius="24px"
-								mg="0 5px"
-							>
-								<FirstHeading fw="300" fs="13px" color="#131313">
-									# 텍스트영역
-								</FirstHeading>
-							</Flex>
-							<Flex
-								wd="95px"
-								ht="29px"
-								bg="#fff"
-								border="1px solid #E5E5E5"
-								radius="24px"
-								mg="0 5px"
-							>
-								<FirstHeading fw="300" fs="13px" color="#131313">
-									# 텍스트영역
-								</FirstHeading>
-							</Flex>
-							<Flex
-								wd="95px"
-								ht="29px"
-								bg="#fff"
-								border="1px solid #E5E5E5"
-								radius="24px"
-								mg="0 5px"
-							>
-								<FirstHeading fw="300" fs="13px" color="#131313">
-									# 텍스트영역
-								</FirstHeading>
-							</Flex>
-						</Flex>
-						<Flex mg="0 0 10px 0">
-							<Flex
-								wd="220px"
-								ht="29px"
-								bg="#fff"
-								border="1px solid #E5E5E5"
-								radius="24px"
-								mg="0 5px"
-							>
-								<FirstHeading fw="300" fs="13px" color="#131313">
-									# 태그가많거나길어지면아래로
-								</FirstHeading>
-							</Flex>
-							<Flex
-								wd="95px"
-								ht="29px"
-								bg="#fff"
-								border="1px solid #E5E5E5"
-								radius="24px"
-								mg="0 5px"
-							>
-								<FirstHeading fw="300" fs="13px" color="#131313">
-									# 텍스트영역
-								</FirstHeading>
-							</Flex>
-						</Flex>
-						<Flex wd="335px" jc="flex-start">
-							<Flex
-								wd="95px"
-								ht="29px"
-								bg="#fff"
-								border="1px solid #E5E5E5"
-								radius="24px"
-								mg="0 5px"
-							>
-								<FirstHeading fw="300" fs="13px" color="#131313">
-									# 텍스트영역
-								</FirstHeading>
-							</Flex>
+							{tagList?.map((tagItem, index) => (
+								<Flex
+									key={index}
+									wd="95px"
+									ht="29px"
+									bg="#fff"
+									border="1px solid #E5E5E5"
+									radius="24px"
+									mg="0 5px"
+								>
+									<FirstHeading fw="300" fs="13px" color="#131313">
+										# {tagItem}
+									</FirstHeading>
+								</Flex>
+							))}
 						</Flex>
 					</Flex>
 				</Flex>

--- a/src/pages/feed/DetailFeedPage.jsx
+++ b/src/pages/feed/DetailFeedPage.jsx
@@ -1,9 +1,8 @@
 import dayjs from "dayjs";
 import { useEffect } from "react";
-import { useSelector } from "react-redux";
-import { useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
-import { Box, FirstHeading, Flex, SecondHeading, Svg } from "../../common";
+import { Box, Flex, Svg, Text } from "../../common";
 import { FeedComment } from "../../components";
 import { __getFeedItem } from "../../redux/modules/feed/feedSlice";
 
@@ -39,132 +38,113 @@ const DetailFeedPage = () => {
 
 	return (
 		<>
-			<Flex
-				dir="column"
-				mw="375px"
-				mxw="375px"
-				mh="667px"
-				mg="0 auto"
-				overflow="auto"
-			>
-				<Flex wd="375px" mg="auto" dir="column">
-					<Flex wd="335px" jc="space-between" mg=" 0 0 10px 0">
+			<Flex dir="column" wd="100%">
+				<Flex wd="100%" dir="column">
+					{/* 헤더 */}
+					<Flex wd="100%" ht="60px" jc="space-between" pd="18px">
 						<Svg variant="chevron" onClick={() => navigate(-1)} />
-						<Flex>
-							<FirstHeading color="#A2A2A2" mg="0 10px 0 0" fs="16" fw="600">
-								수정
-							</FirstHeading>
-							<FirstHeading color="#FD3049" fs="16" fw="600">
-								삭제
-							</FirstHeading>
+						<Flex gap="14px">
+							<Text variant="grey">수정</Text>
+							<Text variant="red">삭제</Text>
 						</Flex>
 					</Flex>
-					<Flex wd="335px" jc="space-between" mg="0 0 20px 0">
-						<Flex wd="335px" jc="flex-start">
+
+					{/* 프로필 영역 */}
+					<Flex wd="100%" ht="66px" jc="space-between" pd="14px 20px">
+						<Flex jc="flex-start" gap="10px">
+							{/* 프로필 사진 */}
 							<Flex>
 								<Box
 									variant="profilePicNormal"
 									profileImageUrl={profileImageUrl}
 								/>
 							</Flex>
-							<Flex dir="column" ai="flex-start">
-								<Flex ai="flex-start" mg="0 0 5px 0">
+							<Flex
+								ht="100%"
+								dir="column"
+								ai="flex-start"
+								jc="space-between"
+								gap="3px"
+							>
+								{/* 닉네임, 뱃지 */}
+								<Flex ht="100%" ai="center" gap="4px">
+									<Text variant="selectedTabMenu">{nickname}</Text>
 									<Flex
-										fw="600"
-										fs="13"
-										onClick={() => {
-											// anotherMemberPage(.memberId);
-										}}
+										wd="60px"
+										ht="20px"
+										bg="#FFF4ED"
+										jc="center"
+										radius="5px"
 									>
-										{nickname}
-										<Flex
-											bc="#FFF4ED"
-											color="#FF8737"
-											fs="10"
-											radius="5px"
-											pd="4px 8px;"
-										>
-											뱃지입니다
-										</Flex>
+										<Text variant="orange">뱃지</Text>
 									</Flex>
 								</Flex>
+
+								{/* 게시글 생성 날짜 */}
 								<Flex>
-									<SecondHeading fw="600" fs="12px" color="#A2A2A2">
+									<Text variant="grey">
 										{dayjs(postedAt).format(`YYYY.MM.DD HH:mm`)}
-									</SecondHeading>
+									</Text>
 								</Flex>
 							</Flex>
 						</Flex>
 						<Flex>
+							{/* 팔로우 버튼 */}
 							<Flex>
 								<Svg variant="follow" onClick={() => {}}></Svg>
 							</Flex>
 						</Flex>
 					</Flex>
-					<Flex
-						wd="335px"
-						fw="600"
-						fs="22"
-						color="#131313"
-						mg="0 0 30px 0"
-						lh="30"
-						jc="flex-start"
-					>
-						{feedTitle}
+
+					{/* 제목 */}
+					<Flex wd="100%" pd="8px 29px 16px" jc="flex-start">
+						<Text variant="title">{feedTitle}</Text>
 					</Flex>
-					<Flex
-						dir="column"
-						ai="flex-start"
-						wd="335px"
-						ht="133px"
-						bc="#F8F8F8"
-						radius="5px"
-						pd="20px"
-						mg="0 0 20px 0"
-					>
-						<Flex mg="5px" dir="column">
-							{todoList?.map((todoItem, index) => (
-								<Flex key={index} dir="row">
-									<Svg variant="feedCheck"></Svg>
-									<FirstHeading fw="300" fs="14px" color="#131313">
-										{todoItem}
-									</FirstHeading>
-								</Flex>
-							))}
-						</Flex>
+
+					{/* 투두리스트 영역 */}
+					<Flex wd="100%" dir="column" radius="5px" pd="8px 18px">
+						{todoList?.map((todoItem, index) => (
+							<Flex
+								key={index}
+								jc="flex-start"
+								wd="100%"
+								dir="row"
+								gap="10px"
+								pd="20px"
+								bg="#F8F8F8"
+							>
+								<Svg variant="feedCheck"></Svg>
+								<Text variant="tabMenu">{todoItem}</Text>
+							</Flex>
+						))}
 					</Flex>
-					<Flex
-						wd="335px"
-						lh="25"
-						fw="300"
-						fs="14px"
-						color="#131313"
-						mg="0 0 20px 0"
-						jc="flex-start"
-					>
-						{feedContent}
+
+					{/* 본문 */}
+					<Flex wd="100%" jc="flex-start" pd="16px 20px 32px">
+						<Text variant="tabMenu">{feedContent}</Text>
 					</Flex>
-					{feedImagesUrlList?.map((feedImg, index) => (
-						<Box variant="feedImg" feedImgUrl={feedImg} />
-					))}
-					<Flex wd="335px" dir="column">
-						<Flex wd="335px" jc="flex-start" mg="0 0 10px 0">
-							{tagList?.map((tagItem, index) => (
-								<Flex
-									key={index}
-									wd="95px"
-									ht="29px"
-									bg="#fff"
-									border="1px solid #E5E5E5"
-									radius="24px"
-									mg="0 5px"
-								>
-									<FirstHeading fw="300" fs="13px" color="#131313">
-										# {tagItem}
-									</FirstHeading>
-								</Flex>
-							))}
-						</Flex>
+
+					{/* 사진 영역*/}
+					<Flex wd="100%" bg="#f8f8f8" dir="column">
+						{feedImagesUrlList?.map((feedImg, index) => (
+							<Box key={index} variant="feedImg" feedImgUrl={feedImg} />
+						))}
+					</Flex>
+
+					{/* 태그 영역 */}
+					<Flex wrap="wrap" gap="8px" wd="100%" jc="flex-start" pd="24px 18px">
+						{tagList?.map((tagItem, index) => (
+							<Flex
+								key={index}
+								ht="29px"
+								border="1px solid #E5E5E5"
+								radius="24px"
+								pd="0 14px"
+								ai="center"
+							>
+								<Text variant="tabMenu"># {tagItem}</Text>
+							</Flex>
+						))}
 					</Flex>
 				</Flex>
 				<FeedComment

--- a/yarn.lock
+++ b/yarn.lock
@@ -3593,6 +3593,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dayjs@^1.11.6:
+  version "1.11.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.6.tgz#2e79a226314ec3ec904e3ee1dd5a4f5e5b1c7afb"
+  integrity sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==
+
 debug@2.6.9, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
피드 디테일 페이지에서 팔로우 버튼 클릭 시 팔로우 요청이 가고 다른 버튼이 렌더링 되도록 구현
피드 디테일 페이지에서 프로필 이미지와 닉네임을 클릭 시 해당 멤버의 프로필 페이지로 이동할 수 있도록 함
피드 상세 페이지 css 작업
피드 상세 게시물 조회 기능 구현
서버에서 받아온 데이터를 화면에 뿌려줌
dayjs 라이브러리 설치

Issue: #76