### PR TITLE
Feat: 무한 스크롤 구현

### DIFF
--- a/src/api/feedListApi.js
+++ b/src/api/feedListApi.js
@@ -1,7 +1,13 @@
 import { instance } from "./instance";
 
-// 피드 리스트 조회
+// 팔로잉 피드 리스트 조회
 export const getFollowingFeedsApi = async payload => {
 	const response = await instance.get(`/api/feed/following?page=${payload}`);
+	return response.data;
+};
+
+// 추천 피드 리스트 조회
+export const getRecommendedFeedsApi = async payload => {
+	const response = await instance.get(`/api/feed/recommended?page=${payload}`);
 	return response.data;
 };

--- a/src/api/feedListApi.js
+++ b/src/api/feedListApi.js
@@ -1,0 +1,7 @@
+import { instance } from "./instance";
+
+// 피드 리스트 조회
+export const getFollowingFeedsApi = async payload => {
+	const response = await instance.get(`/api/feed/following?page=${payload}`);
+	return response.data;
+};

--- a/src/components/nav/NavBelow.jsx
+++ b/src/components/nav/NavBelow.jsx
@@ -31,7 +31,7 @@ const NavBelow = () => {
 					gap="8px"
 					dir="column"
 					cursor="pointer"
-					onClick={() => navigate(`/feed`)}
+					onClick={() => navigate(`/feed/following`)}
 				>
 					<Box variant="navIconBox" type="speechBubble" />
 					<Text variant="navText">피드</Text>

--- a/src/pages/feed/FeedPage.jsx
+++ b/src/pages/feed/FeedPage.jsx
@@ -1,20 +1,27 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { Box, Flex, Svg, Text } from "../../common";
 import { FeedItem, NavBelow } from "../../components";
-import {
-	__getFollowingFeeds,
-	__getRecommendedFeeds,
-} from "../../redux/modules/feed/feedSlice";
+import { __getRecommendedFeeds } from "../../redux/modules/feed/feedSlice";
+import { __getFollowingFeeds } from "../../redux/modules/middleware/feedListThunk";
 
 const FeedPage = () => {
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
-	const feedList = useSelector(state => state.feed.feedList);
+	const target = useRef(null);
+	const { feedList } = useSelector(state => state.feed);
 
 	useEffect(() => {
-		dispatch(__getFollowingFeeds());
+		const observer = new IntersectionObserver(([entry]) => {
+			if (entry.isIntersecting) {
+				dispatch(__getFollowingFeeds());
+			}
+		});
+		observer.observe(target.current);
+		return () => {
+			observer.disconnect(observer);
+		};
 	}, []);
 
 	// 상단 탭 메뉴 ui 상태 관리
@@ -69,8 +76,8 @@ const FeedPage = () => {
 					{feedList.map(feedItem => (
 						<FeedItem key={feedItem.feedId} feedItem={feedItem} />
 					))}
+					<div ref={target} />
 				</Box>
-				<Flex ht="80px" />
 			</Flex>
 			<NavBelow />
 		</>

--- a/src/pages/feed/FeedPage.jsx
+++ b/src/pages/feed/FeedPage.jsx
@@ -1,30 +1,10 @@
-import { useEffect, useRef, useState } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
 import { Box, Flex, Svg, Text } from "../../common";
-import { FeedItem, NavBelow } from "../../components";
-import { __getRecommendedFeeds } from "../../redux/modules/feed/feedSlice";
-import { __getFollowingFeeds } from "../../redux/modules/middleware/feedListThunk";
+import { NavBelow } from "../../components";
 
 const FeedPage = () => {
-	const dispatch = useDispatch();
 	const navigate = useNavigate();
-	const target = useRef(null);
-	const { feedList, isNextPageExist } = useSelector(state => state.feed);
-
-	useEffect(() => {
-		if (isNextPageExist) {
-			const observer = new IntersectionObserver(([entry]) => {
-				if (entry.isIntersecting) {
-					dispatch(__getFollowingFeeds());
-				}
-			});
-			observer.observe(target.current);
-			return () => {
-				observer.disconnect(observer);
-			};
-		}
-	}, [isNextPageExist]);
 
 	// 상단 탭 메뉴 ui 상태 관리
 	const [followingFeedListMenuUiType, setFollowingFeedListMenuUiType] =
@@ -34,14 +14,14 @@ const FeedPage = () => {
 
 	// 피드 리스트 종류 변경 핸들러
 	const changeFeedListTypeHandler = feedListType => {
-		if (feedListType === "followingFeedList") {
-			dispatch(__getFollowingFeeds());
-			setFollowingFeedListMenuUiType("selectedTabMenu");
-			setRecommendedFeedListMenuUiType("tabMenu");
-		} else {
-			dispatch(__getRecommendedFeeds());
+		if (feedListType === "recommendedFeedList") {
+			navigate(`/feed/recommended`);
 			setRecommendedFeedListMenuUiType("selectedTabMenu");
 			setFollowingFeedListMenuUiType("tabMenu");
+		} else {
+			navigate(`/feed/following`);
+			setFollowingFeedListMenuUiType("selectedTabMenu");
+			setRecommendedFeedListMenuUiType("tabMenu");
 		}
 	};
 
@@ -66,7 +46,7 @@ const FeedPage = () => {
 						<Text variant={followingFeedListMenuUiType}>팔로잉</Text>
 					</Box>
 					<Box
-						onClick={() => changeFeedListTypeHandler("recommendedFeeds")}
+						onClick={() => changeFeedListTypeHandler("recommendedFeedList")}
 						variant={recommendedFeedListMenuUiType}
 					>
 						<Text variant={recommendedFeedListMenuUiType}>추천 피드</Text>
@@ -74,15 +54,7 @@ const FeedPage = () => {
 				</Flex>
 
 				{/* 피드 리스트 */}
-				<Box variant="feedScrollArea">
-					{feedList.map(feedItem => (
-						<FeedItem key={feedItem.feedId} feedItem={feedItem} />
-					))}
-					{isNextPageExist ? null : (
-						<Flex ht="80px" border="25px solid transparent" />
-					)}
-					<div ref={target} />
-				</Box>
+				<Outlet></Outlet>
 			</Flex>
 			<NavBelow />
 		</>

--- a/src/pages/feed/FeedPage.jsx
+++ b/src/pages/feed/FeedPage.jsx
@@ -10,19 +10,21 @@ const FeedPage = () => {
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
 	const target = useRef(null);
-	const { feedList } = useSelector(state => state.feed);
+	const { feedList, isNextPageExist } = useSelector(state => state.feed);
 
 	useEffect(() => {
-		const observer = new IntersectionObserver(([entry]) => {
-			if (entry.isIntersecting) {
-				dispatch(__getFollowingFeeds());
-			}
-		});
-		observer.observe(target.current);
-		return () => {
-			observer.disconnect(observer);
-		};
-	}, []);
+		if (isNextPageExist) {
+			const observer = new IntersectionObserver(([entry]) => {
+				if (entry.isIntersecting) {
+					dispatch(__getFollowingFeeds());
+				}
+			});
+			observer.observe(target.current);
+			return () => {
+				observer.disconnect(observer);
+			};
+		}
+	}, [isNextPageExist]);
 
 	// 상단 탭 메뉴 ui 상태 관리
 	const [followingFeedListMenuUiType, setFollowingFeedListMenuUiType] =
@@ -76,6 +78,9 @@ const FeedPage = () => {
 					{feedList.map(feedItem => (
 						<FeedItem key={feedItem.feedId} feedItem={feedItem} />
 					))}
+					{isNextPageExist ? null : (
+						<Flex ht="80px" border="25px solid transparent" />
+					)}
 					<div ref={target} />
 				</Box>
 			</Flex>

--- a/src/pages/feed/FollowingFeedListPage.jsx
+++ b/src/pages/feed/FollowingFeedListPage.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Box, Flex } from "../../common";
+import { FeedItem } from "../../components";
+import { __getFollowingFeeds } from "../../redux/modules/middleware/feedListThunk";
+
+const FollowingFeedListPage = () => {
+	const dispatch = useDispatch();
+	const target = useRef(null);
+	const { followingFeedList, isNextFollowingFeedPageExist } = useSelector(
+		state => state.feed,
+	);
+
+	useEffect(() => {
+		if (isNextFollowingFeedPageExist) {
+			const observer = new IntersectionObserver(([entry]) => {
+				if (entry.isIntersecting) {
+					dispatch(__getFollowingFeeds());
+				}
+			});
+			observer.observe(target.current);
+			return () => {
+				observer.disconnect(observer);
+			};
+		}
+	}, [isNextFollowingFeedPageExist]);
+
+	return (
+		<Box variant="feedScrollArea">
+			{followingFeedList.map(feedItem => (
+				<FeedItem key={feedItem.feedId} feedItem={feedItem} />
+			))}
+			{isNextFollowingFeedPageExist ? null : (
+				<Flex ht="80px" border="25px solid transparent" />
+			)}
+			<div ref={target} />
+		</Box>
+	);
+};
+
+export default FollowingFeedListPage;

--- a/src/pages/feed/RecommendedFeedListPage.jsx
+++ b/src/pages/feed/RecommendedFeedListPage.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Box, Flex } from "../../common";
+import { FeedItem, NavBelow } from "../../components";
+import { __getRecommendedFeeds } from "../../redux/modules/middleware/feedListThunk";
+
+const RecommendedFeedListPage = () => {
+	const dispatch = useDispatch();
+	const target = useRef(null);
+	const { recommendedFeedList, isNextRecommendedFeedPageExist } = useSelector(
+		state => state.feed,
+	);
+
+	useEffect(() => {
+		if (isNextRecommendedFeedPageExist) {
+			const observer = new IntersectionObserver(([entry]) => {
+				if (entry.isIntersecting) {
+					dispatch(__getRecommendedFeeds());
+				}
+			});
+			observer.observe(target.current);
+			return () => {
+				observer.disconnect(observer);
+			};
+		}
+	}, [isNextRecommendedFeedPageExist]);
+
+	return (
+		<>
+			<Box variant="feedScrollArea">
+				{recommendedFeedList.map(feedItem => (
+					<FeedItem key={feedItem.feedId} feedItem={feedItem} />
+				))}
+				{isNextRecommendedFeedPageExist ? null : (
+					<Flex ht="80px" border="25px solid transparent" />
+				)}
+				<div ref={target} />
+			</Box>
+			<NavBelow />
+		</>
+	);
+};
+
+export default RecommendedFeedListPage;

--- a/src/pages/feed/index.js
+++ b/src/pages/feed/index.js
@@ -1,4 +1,13 @@
 import AddFeedPage from "./AddFeedPage";
 import DetailFeedPage from "./DetailFeedPage";
+import FollowingFeedListPage from "./FollowingFeedListPage";
+import RecommendedFeedListPage from "./RecommendedFeedListPage";
+import FeedPage from "./FeedPage";
 
-export { AddFeedPage, DetailFeedPage };
+export {
+	AddFeedPage,
+	DetailFeedPage,
+	FollowingFeedListPage,
+	RecommendedFeedListPage,
+	FeedPage,
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,3 @@
-import FeedPage from "./feed/FeedPage";
 import SignInPage from "./join/SignInPage";
 import SignUpPage from "./join/SignUpPage";
 import TodoListPage from "./todoList/TodoListPage";
@@ -9,6 +8,11 @@ import ProfileEditPage from "./profile/ProfileEditPage";
 import PasswordChangePage from "./profile/PasswordChangePage";
 import FollowingPage from "./profile/FollowingPage";
 import FollowerPage from "./profile/FollowerPage";
+import {
+	FollowingFeedListPage,
+	RecommendedFeedListPage,
+	FeedPage,
+} from "./feed";
 
 export {
 	SignInPage,
@@ -21,5 +25,7 @@ export {
 	FollowingPage,
 	FollowerPage,
 	DetailFeedPage,
+	FollowingFeedListPage,
+	RecommendedFeedListPage,
 	FeedPage,
 };

--- a/src/redux/modules/feed/feedSlice.js
+++ b/src/redux/modules/feed/feedSlice.js
@@ -190,6 +190,7 @@ const initialState = {
 	feedItem: {},
 	commentList: [],
 	page: 0,
+	isNextPageExist: true,
 };
 
 export const feedSlice = createSlice({
@@ -259,6 +260,9 @@ export const feedSlice = createSlice({
 			.addCase(__getFollowingFeeds.fulfilled, (state, action) => {
 				state.feedList.push(...action.payload);
 				state.page += 1;
+				if (action.payload.length < 5) {
+					state.isNextPageExist = false;
+				}
 			})
 			// 추천 피드 조회 성공
 			.addCase(__getRecommendedFeeds.fulfilled, (state, action) => {

--- a/src/redux/modules/feed/feedSlice.js
+++ b/src/redux/modules/feed/feedSlice.js
@@ -1,7 +1,10 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { serverUrl } from "../../api";
 import axios from "axios";
-import { __getFollowingFeeds } from "../middleware/feedListThunk";
+import {
+	__getFollowingFeeds,
+	__getRecommendedFeeds,
+} from "../middleware/feedListThunk";
 
 const accessToken = localStorage.getItem("accessToken");
 
@@ -36,21 +39,6 @@ export const __getFeedItem = createAsyncThunk(
 	async (payload, thunkAPI) => {
 		try {
 			const response = await axios.get(`${serverUrl}/api/feed/${payload}`, {
-				headers: { Authorization: accessToken },
-			});
-			return thunkAPI.fulfillWithValue(response.data);
-		} catch (error) {
-			return thunkAPI.rejectWithValue(error.response.data);
-		}
-	},
-);
-
-// 추천 피드 조회 Thunk
-export const __getRecommendedFeeds = createAsyncThunk(
-	"feed/getRecommendedFeeds",
-	async (_, thunkAPI) => {
-		try {
-			const response = await axios.get(`${serverUrl}/api/feed/recommended`, {
 				headers: { Authorization: accessToken },
 			});
 			return thunkAPI.fulfillWithValue(response.data);
@@ -181,7 +169,8 @@ export const __deleteComment = createAsyncThunk(
 );
 
 const initialState = {
-	feedList: [],
+	followingFeedList: [],
+	recommendedFeedList: [],
 	checkedList: [],
 	tagList: [],
 	photoList: [],
@@ -189,8 +178,10 @@ const initialState = {
 	successTodo: [],
 	feedItem: {},
 	commentList: [],
-	page: 0,
-	isNextPageExist: true,
+	followingFeedPageNum: 0,
+	recommendedFeedPageNum: 0,
+	isNextFollowingFeedPageExist: true,
+	isNextRecommendedFeedPageExist: true,
 };
 
 export const feedSlice = createSlice({
@@ -258,15 +249,19 @@ export const feedSlice = createSlice({
 			})
 			// 팔로잉 피드 조회 성공
 			.addCase(__getFollowingFeeds.fulfilled, (state, action) => {
-				state.feedList.push(...action.payload);
-				state.page += 1;
+				state.followingFeedList.push(...action.payload);
+				state.followingFeedPageNum += 1;
 				if (action.payload.length < 5) {
-					state.isNextPageExist = false;
+					state.isNextFollowingFeedPageExist = false;
 				}
 			})
 			// 추천 피드 조회 성공
 			.addCase(__getRecommendedFeeds.fulfilled, (state, action) => {
-				state.feedList = action.payload;
+				state.recommendedFeedList.push(...action.payload);
+				state.recommendedFeedPageNum += 1;
+				if (action.payload.length < 5) {
+					state.isNextRecommendedFeedPageExist = false;
+				}
 			})
 			// 피드 단건 조회 성공
 			.addCase(__getFeedItem.fulfilled, (state, action) => {

--- a/src/redux/modules/feed/feedSlice.js
+++ b/src/redux/modules/feed/feedSlice.js
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { serverUrl } from "../../api";
 import axios from "axios";
+import { __getFollowingFeeds } from "../middleware/feedListThunk";
 
 const accessToken = localStorage.getItem("accessToken");
 
@@ -25,20 +26,6 @@ export const __getSuccessTodo = createAsyncThunk(
 			return thunkAPI.fulfillWithValue(data);
 		} catch (e) {
 			return thunkAPI.rejectWithValue(e.code);
-		}
-	},
-);
-// 팔로잉 피드 조회 Thunk
-export const __getFollowingFeeds = createAsyncThunk(
-	"feed/getFollowingFeeds",
-	async (_, thunkAPI) => {
-		try {
-			const response = await axios.get(`${serverUrl}/api/feed/following`, {
-				headers: { Authorization: accessToken },
-			});
-			return thunkAPI.fulfillWithValue(response.data);
-		} catch (error) {
-			return thunkAPI.rejectWithValue(error.response.data);
 		}
 	},
 );
@@ -202,6 +189,7 @@ const initialState = {
 	successTodo: [],
 	feedItem: {},
 	commentList: [],
+	page: 0,
 };
 
 export const feedSlice = createSlice({
@@ -269,7 +257,8 @@ export const feedSlice = createSlice({
 			})
 			// 팔로잉 피드 조회 성공
 			.addCase(__getFollowingFeeds.fulfilled, (state, action) => {
-				state.feedList = action.payload;
+				state.feedList.push(...action.payload);
+				state.page += 1;
 			})
 			// 추천 피드 조회 성공
 			.addCase(__getRecommendedFeeds.fulfilled, (state, action) => {

--- a/src/redux/modules/middleware/feedListThunk.js
+++ b/src/redux/modules/middleware/feedListThunk.js
@@ -1,13 +1,30 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import { getFollowingFeedsApi } from "../../../api/feedListApi";
+import {
+	getFollowingFeedsApi,
+	getRecommendedFeedsApi,
+} from "../../../api/feedListApi";
 
 // 팔로잉 피드 조회 Thunk
 export const __getFollowingFeeds = createAsyncThunk(
 	"feed/getFollowingFeeds",
 	async (payload, thunkAPI) => {
 		try {
-			const { page } = thunkAPI.getState().feed;
-			const response = await getFollowingFeedsApi(page);
+			const { followingFeedPageNum } = thunkAPI.getState().feed;
+			const response = await getFollowingFeedsApi(followingFeedPageNum);
+			return thunkAPI.fulfillWithValue(response);
+		} catch (error) {
+			return thunkAPI.rejectWithValue(error);
+		}
+	},
+);
+
+// 추천 피드 조회 Thunk
+export const __getRecommendedFeeds = createAsyncThunk(
+	"feed/getRecommendedFeeds",
+	async (payload, thunkAPI) => {
+		try {
+			const { recommendedFeedPageNum } = thunkAPI.getState().feed;
+			const response = await getRecommendedFeedsApi(recommendedFeedPageNum);
 			return thunkAPI.fulfillWithValue(response);
 		} catch (error) {
 			return thunkAPI.rejectWithValue(error);

--- a/src/redux/modules/middleware/feedListThunk.js
+++ b/src/redux/modules/middleware/feedListThunk.js
@@ -1,0 +1,16 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { getFollowingFeedsApi } from "../../../api/feedListApi";
+
+// 팔로잉 피드 조회 Thunk
+export const __getFollowingFeeds = createAsyncThunk(
+	"feed/getFollowingFeeds",
+	async (payload, thunkAPI) => {
+		try {
+			const { page } = thunkAPI.getState().feed;
+			const response = await getFollowingFeedsApi(page);
+			return thunkAPI.fulfillWithValue(response);
+		} catch (error) {
+			return thunkAPI.rejectWithValue(error);
+		}
+	},
+);

--- a/src/shared/Router.js
+++ b/src/shared/Router.js
@@ -10,6 +10,8 @@ import {
 	FollowingPage,
 	FollowerPage,
 	DetailFeedPage,
+	FollowingFeedListPage,
+	RecommendedFeedListPage,
 	FeedPage,
 } from "../pages";
 
@@ -29,7 +31,10 @@ const Router = () => {
 					<Route path="/profile/:id/following" element={<FollowingPage />} />
 					<Route path="/profile/:id/follower" element={<FollowerPage />} />
 					<Route path="/todolist" element={<TodoListPage />} />
-					<Route path="/feed" element={<FeedPage />} />
+					<Route path="/feed" element={<FeedPage />}>
+						<Route path="following" element={<FollowingFeedListPage />} />
+						<Route path="recommended" element={<RecommendedFeedListPage />} />
+					</Route>
 					<Route path="/addFeed" element={<AddFeedPage />} />
 					<Route path="/feed/:id" element={<DetailFeedPage />} />
 				</Routes>


### PR DESCRIPTION
1. 타켓이 뷰에 보일 때마다 get 요청을 보내도록 하여 무한 스크롤 기능 구현
2. 가져올 페이지가 없을 때에는 타켓이 뷰에 노출되어도 get요청을 보내지 않도록 함
3. 상단, 하단 네비게이션바를 재사용하기 위해 컴포넌트 재배치
  FeedPage.jsx 에 네이비게이션 바를 배치한 후 Outlet 추가
  FeedPage를 엘리먼트로 가지고 있는 라우트의 자식 라우트로 FollowingFeedLisPage와 RecommendedFeedPage 추가
  FollowingFeedLisPage.jsx 에서는 팔로잉 피드 목록 조회를,
  RecommendedFeedPage.jsx 에서는 추천 피드 목록 조회를 할 수 있도록 분리
