### PR TITLE
Fix: 토큰이 없을 때 RefrexhToken 컴포넌트에서 생기던 오류 해결

### DIFF
--- a/src/shared/Router.js
+++ b/src/shared/Router.js
@@ -37,7 +37,14 @@ const Router = () => {
 					<Route path="/api/members/login/kakao" element={<KakaoLogin />} />
 					<Route path="/api/members/login/naver" element={<NaverLogin />} />
 					<Route path="/api/members/login/google" element={<GoogleLogin />} />
-					<Route path="/*" element={<RefreshToken />}>
+					<Route
+						path="/*"
+						element={
+							<PrivateRoute>
+								<RefreshToken />
+							</PrivateRoute>
+						}
+					>
 						<Route
 							path="profile/:id"
 							element={


### PR DESCRIPTION
다른 컴포넌트와 마찬가지로 PrivateRoute를 거치도록 함