### PR TITLE
Fix: 내 블럭 페이지 버그 수정

### DIFF
--- a/src/common/box/Box.jsx
+++ b/src/common/box/Box.jsx
@@ -410,6 +410,7 @@ const StBox = styled.div`
 				`;
 			case "profileBox":
 				return css`
+					cursor: pointer;
 					position: relative;
 					padding-bottom: 100px;
 				`;

--- a/src/components/profile/Profile.jsx
+++ b/src/components/profile/Profile.jsx
@@ -122,19 +122,34 @@ const Profile = () => {
 					pd="40px"
 					bg="#F8F8F8"
 				>
-					<Flex onClick={() => navigate("/profile/myblocks")} cursor="pointer">
-						<SecondHeading fw="300" fs="12px" color="#666666">
-							내 블럭
-							<Flex
-								fw="600"
-								fs="19"
-								color="#131313"
-								ta="center"
-								mg="10px 0 0 0"
-							>
-								{profile.countFeed}
-							</Flex>
-						</SecondHeading>
+					<Flex onClick={() => navigate(`myblocks`)} cursor="pointer" Z>
+						{decodeToken.memberId === profile.memberId ? (
+							<SecondHeading fw="300" fs="12px" color="#666666">
+								내 블럭
+								<Flex
+									fw="600"
+									fs="19"
+									color="#131313"
+									ta="center"
+									mg="10px 0 0 0"
+								>
+									{profile.countFeed}
+								</Flex>
+							</SecondHeading>
+						) : (
+							<SecondHeading fw="300" fs="12px" color="#666666">
+								블럭
+								<Flex
+									fw="600"
+									fs="19"
+									color="#131313"
+									ta="center"
+									mg="10px 0 0 0"
+								>
+									{profile.countFeed}
+								</Flex>
+							</SecondHeading>
+						)}
 					</Flex>
 					<SecondHeading fw="300" fs="12px" color="#666666">
 						팔로잉
@@ -210,18 +225,17 @@ const Profile = () => {
 				</Swiper>
 				<Flex wd="100%" bb="2px solid #EFEFEF" mg="20px 0 0 0" />
 				<Flex wd="331px" ht="51px" jc="flex-start">
-					<Flex
-						onClick={() => navigate(`/profile/myblocks`)}
-						cursor="pointer"
-						ht="100%"
-					>
-						<SecondHeading fw="600" fs="15px" mg="0 10px 0 0">
-							내가 쌓은 블럭
-						</SecondHeading>
-						<Svg
-							variant="rightArrow"
-							onClick={() => navigate("/feed/following")}
-						></Svg>
+					<Flex onClick={() => navigate(`myblocks`)} cursor="pointer" ht="100%">
+						{decodeToken.memberId === Number(id) ? (
+							<SecondHeading fw="600" fs="15px" mg="0 10px 0 0">
+								내가 쌓은 블럭
+							</SecondHeading>
+						) : (
+							<SecondHeading fw="600" fs="15px" mg="0 10px 0 0">
+								쌓은 블럭
+							</SecondHeading>
+						)}
+						<Svg variant="rightArrow"></Svg>
 					</Flex>
 				</Flex>
 				{profile.countFeed === 0 ? (
@@ -235,7 +249,7 @@ const Profile = () => {
 						</Flex>
 					</>
 				) : (
-					<Box variant="profileBox">
+					<Box onClick={() => navigate(`myblocks`)} variant="profileBox">
 						<Flex jc="flex-end" position="absolute" right="10px" top="-38px">
 							<Svg variant="block" />
 						</Flex>

--- a/src/pages/profile/MyFeedPage.jsx
+++ b/src/pages/profile/MyFeedPage.jsx
@@ -1,7 +1,7 @@
 import jwtDecode from "jwt-decode";
 import { useEffect, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Box, Flex, FloatingAddBtn, Text, white } from "../../common";
 import { FeedItem, NavBelow } from "../../components";
 import { resetMyFeed } from "../../redux/modules/feed/feedSlice";
@@ -10,6 +10,7 @@ import { __getMyFeeds } from "../../redux/modules/middleware/feedListThunk";
 const MyFeedPage = () => {
 	const navigate = useNavigate();
 	const dispatch = useDispatch();
+	const { id } = useParams();
 	const target = useRef(null);
 	const { myFeedList, isNextmyFeedPageExist } = useSelector(
 		state => state.feed,
@@ -22,7 +23,7 @@ const MyFeedPage = () => {
 		if (isNextmyFeedPageExist) {
 			const observer = new IntersectionObserver(([entry]) => {
 				if (entry.isIntersecting) {
-					dispatch(__getMyFeeds(decodedToken.memberId));
+					dispatch(__getMyFeeds(id));
 				}
 			});
 			observer.observe(target.current);
@@ -63,7 +64,11 @@ const MyFeedPage = () => {
 					<Flex wd="19px" ht="15px" bi="url(/images/back.svg)" />
 				</Flex>
 				<Flex mg="0 30px 0 0">
-					<Text variant="title3">내가 쌓은 블럭</Text>
+					{decodedToken.memberId === Number(id) ? (
+						<Text variant="title3">내가 쌓은 블럭</Text>
+					) : (
+						<Text variant="title3">쌓은 블럭</Text>
+					)}
 				</Flex>
 				<div />
 			</Flex>
@@ -83,7 +88,11 @@ const MyFeedPage = () => {
 				<Flex wd="100%" ht="100vh">
 					<Flex dir="column" ht="100%" gap="15px">
 						<Flex wd="107px" ht="64px" bi="url(/images/blockStacksGrey.svg)" />
-						<Text variant="body2Medium">내가 쌓은 블록이 없습니다.</Text>
+						{decodedToken.memberId === Number(id) ? (
+							<Text variant="body2Medium">내가 쌓은 블록이 없습니다.</Text>
+						) : (
+							<Text variant="body2Medium">쌓은 블럭이 없습니다.</Text>
+						)}
 					</Flex>
 				</Flex>
 			)}

--- a/src/shared/Router.js
+++ b/src/shared/Router.js
@@ -111,7 +111,7 @@ const Router = () => {
 							}
 						/>
 						<Route
-							path="profile/myblocks"
+							path="profile/:id/myblocks"
 							element={
 								<PrivateRoute>
 									<MyFeedPage />


### PR DESCRIPTION
- 다른 멤버의 프로필에서 "쌓은 블럭"을 눌렀을 때 해당 멤버의 myblocks 페이지로 이동하도록 함
- "쌓은 블럭" 옆 화살표의 클릭 이벤트를 삭제하여 쌓은 블럭 페이지가 아닌 피드 페이지로 이동하던 버그 수정
- "쌓은 블럭" 목록을 클릭했을 때에도 해당 페이지로 이동할 수 있도록 클릭 영역 확장